### PR TITLE
Docs: Certificate Builder (New / V2)

### DIFF
--- a/250-free-addons/16-certificate-builder-v2.mdx
+++ b/250-free-addons/16-certificate-builder-v2.mdx
@@ -10,10 +10,11 @@ It works like a simple design tool — no code needed. This is different from th
 
 <Callout>
   {" "}
-  **Requirement:** The new builder needs [Masteriyo Pro](https://masteriyo.com/pricing/).
-  The Certificate Builder add-on itself is free, but creating a certificate with
-  the new builder asks for an active Pro license. If your license is missing or expired,
-  a license popup appears when you click **Add New Certificate**.
+  **Requirement:** The new builder needs [Masteriyo
+  Pro](https://masteriyo.com/pricing/). The Certificate Builder add-on itself is
+  free, but creating a certificate with the new builder asks for an active Pro
+  license. If your license is missing or expired, a license popup appears when
+  you click **Add New Certificate**.
 </Callout>
 
 ---
@@ -32,7 +33,7 @@ It works like a simple design tool — no code needed. This is different from th
 1. In your WordPress dashboard, go to **Masteriyo > Certificates**.
 2. You will see the certificates screen. This is where all your certificates live.
 
-![The Certificates screen with the certificate list and toolbar](https://img.masteriyo.com/w:auto/h:auto/q:auto/id:dc48369195f3948369655b0425c5e3d9/directUpload/Certificates-list.png)
+![The Certificates screen with the certificate list and toolbar](https://img.masteriyo.com/w:auto/h:auto/q:auto/id:95c75f9d3cfcda0ffa4b05559a05f226/directUpload/Certificates-list.png)
 
 Here is what the screen offers:
 
@@ -58,7 +59,6 @@ Each certificate shows as a card with a small preview, its name, a **Draft** lab
    </Callout>
 
 2. The **Choose a Template** screen opens. Pick how you want to start:
-
    - **Create from blank** — start with an empty page.
    - **A starter template** — pick one of the ready-made designs and customize it.
 
@@ -78,8 +78,8 @@ Each certificate shows as a card with a small preview, its name, a **Draft** lab
    <Callout>
      {" "}
      **Tip:** Keep the page a normal certificate size (A4 or Letter works well).
-     Width and height cannot be more than 100 inches, and very large pages can be
-     slow to preview.
+     Width and height cannot be more than 100 inches, and very large pages can
+     be slow to preview.
    </Callout>
 
 4. Click **Create**. The certificate opens in the editor, ready to design.
@@ -96,22 +96,22 @@ The editor is where you build the design. It has three main areas:
 - **Left panel** — four tabs for adding and configuring content: **Elements**, **Library**, **Background**, and **Settings**.
 - **Right panel** — the **Layers** list, showing every item on the page so you can select, reorder, and group them.
 
-![The certificate editor with the left panel, canvas, and Layers panel](https://img.masteriyo.com/w:auto/h:auto/q:auto/id:595262e8d4a748d8a5441bd6f295334c/directUpload/Editor_Overview.png)
+![The certificate editor with the left panel, canvas, and Layers panel](https://img.masteriyo.com/files/id:0f45e3ae7ef9238e01d5cc0dc7d623f7/directUpload/Builder_video_.webm)
 
 <Callout>
   {" "}
-  **Note:** Each certificate is a **single page**. To change its size or orientation
-  later, use **Settings → Resize Project** (see below).
+  **Note:** Each certificate is a **single page**. To change its size or
+  orientation later, use **Settings → Resize Project** (see below).
 </Callout>
 
 ### The left panel tabs
 
-| Tab            | What it does                                                                                                                                                                         |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Elements**   | Add new items to the page — **Text**, **Image**, **Shape**, **Divider**, and the **Masteriyo LMS** elements that fill in student and course details (see [Adding Student & Course Details (Elements)](#adding-student--course-details-elements)). |
-| **Library**    | Insert shapes and pictures, and upload images from your computer (they go to your WordPress Media Library).                                                                          |
-| **Background** | Set the page background. Pick one of the ready-made Masteriyo patterns, or use the **Edit** button above the canvas to add or replace a background image.                            |
-| **Settings**   | Document settings — **Resize Project**, **View**, and the **Pixel Guide** toggle. The title at the top shows the certificate name (click the pencil to rename) and the page size.    |
+| Tab            | What it does                                                                                                                                                                                   |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Elements**   | Add new items to the page — **Text**, **Image**, **Shape**, **Divider**, and the **Masteriyo LMS** elements that fill in student and course details (see [Adding Elements](#adding-elements)). |
+| **Library**    | Insert shapes and pictures, and upload images from your computer (they go to your WordPress Media Library).                                                                                    |
+| **Background** | Set the page background. Pick one of the ready-made Masteriyo patterns, or use the **Edit** button above the canvas to add or replace a background image.                                      |
+| **Settings**   | Document settings — **Resize Project**, **View**, and the **Pixel Guide** toggle. The title at the top shows the certificate name (click the pencil to rename) and the page size.              |
 
 ### Adding and arranging elements
 
@@ -173,19 +173,19 @@ These shortcuts speed up designing. On a Mac, use **⌘ (Cmd)** wherever **Ctrl*
 
 <Callout>
   {" "}
-  **Tip:** Many of these actions are also on the right-click menu of a selected element
-  — copy, paste, duplicate, delete, layer order, and alignment.
+  **Tip:** Many of these actions are also on the right-click menu of a selected
+  element — copy, paste, duplicate, delete, layer order, and alignment.
 </Callout>
 
 ---
 
-## AddingElements
+## Adding Elements
 
 These elements are placeholders that fill in automatically for each student. For example, instead of typing a name, you drop in the **Student Name** element — and every student sees their own name on their certificate.
 
 In the editor, open the **Masteriyo LMS** group in the left panel and drag the element you want onto the page. In the editor it shows as a placeholder like `{ Student Name }`; on the real certificate it becomes the student's actual name.
 
-| Elements                                                | What it shows                                                                                 |
+| Elements                                               | What it shows                                                                                 |
 | ------------------------------------------------------ | --------------------------------------------------------------------------------------------- |
 | **Student Name** (also **First Name** / **Last Name**) | The student's name.                                                                           |
 | **Course Title**                                       | The name of the completed course.                                                             |
@@ -195,16 +195,16 @@ In the editor, open the **Masteriyo LMS** group in the left panel and drag the e
 | **Course Duration**                                    | How long the course took.                                                                     |
 | **Instructor Name**                                    | The course instructor's name.                                                                 |
 | **Current Date / Current Time / Timestamp**            | The date/time the certificate is generated.                                                   |
-| **QR Code** <ProBadge size="xs" />                                    | A scannable code that links to the certificate's verification page.                           |
-| **Verify Code** <ProBadge size="xs" />                                | A unique text code used to verify the certificate.                                            |
-| **Grade Result** <ProBadge size="xs" />                               | The student's final grade. _Appears only if the Gradebook add-on is active._                  |
-| **Co-Instructors** <ProBadge size="xs" />                             | Names of additional instructors. _Appears only if the Multiple Instructors add-on is active._ |
+| **QR Code** <ProBadge size="xs" />                     | A scannable code that links to the certificate's verification page.                           |
+| **Verify Code** <ProBadge size="xs" />                 | A unique text code used to verify the certificate.                                            |
+| **Grade Result** <ProBadge size="xs" />                | The student's final grade. _Appears only if the Gradebook add-on is active._                  |
+| **Co-Instructors** <ProBadge size="xs" />              | Names of additional instructors. _Appears only if the Multiple Instructors add-on is active._ |
 
 <Callout>
   {" "}
-  **Note:** You only see the fields that apply to your setup. **Grade Result** needs
-  the **Gradebook** add-on and **Co-Instructors** needs the **Multiple Instructors**
-  add-on before they appear.
+  **Note:** You only see the fields that apply to your setup. **Grade Result**
+  needs the **Gradebook** add-on and **Co-Instructors** needs the **Multiple
+  Instructors** add-on before they appear.
 </Callout>
 
 ---
@@ -218,8 +218,8 @@ To check your design or get a PDF, open the menu (the **⋮** icon) in the edito
 
 <Callout>
   {" "}
-  **Tip:** If Preview or Export does nothing, your page may be too large to render.
-  Reduce the width or height and try again.
+  **Tip:** If Preview or Export does nothing, your page may be too large to
+  render. Reduce the width or height and try again.
 </Callout>
 
 ---
@@ -265,6 +265,15 @@ A certificate is only awarded once you attach it to a course.
   see yours, open it in the editor and publish it first.
 </Callout>
 
+<Callout>
+  {" "}
+  **Note:** Certificates are generated fresh on each download — they are not
+  stored per student. So if a course previously used an older Certificate (V1)
+  and you switch it to a Certificate V2 here, every student (including those who
+  finished earlier) gets the **latest** assigned certificate the next time they
+  preview or download it.
+</Callout>
+
 ---
 
 ## What Students See
@@ -288,25 +297,23 @@ Masteriyo has **two** certificate builders:
 
 Here's what each gives you:
 
-| Capability                                     | Free        | Pro                                           |
-| ---------------------------------------------- | ----------- | --------------------------------------------- |
-| Classic Certificate Builder                    | ✓           | ✓                                             |
-| New drag-and-drop builder (this guide)         | —           | ✓                                             |
-| Published certificate templates                | Up to **2** | Unlimited                                     |
-| Upload custom fonts (**Install Custom Fonts**) | —           | ✓                                             |
-| Element — **QR Code**                          | —           | ✓                                             |
-| Element — **Verify Code**                      | —           | ✓                                             |
-| Element — **Grade Result**                     | —           | ✓ (needs the **Gradebook** add-on)            |
-| Element — **Co-Instructors**                   | —           | ✓ (needs the **Multiple Instructors** add-on) |
-| Download / email certificates to students      | ✓           | ✓                                             |
-| Certificate sharing                            | ✓           | ✓                                             |
+| Capability                                | Free        | Pro                                           |
+| ----------------------------------------- | ----------- | --------------------------------------------- |
+| New drag-and-drop builder                 | —           | ✓                                             |
+| Published certificate templates           | Up to **2** | Unlimited                                     |
+| Element — **QR Code**                     | —           | ✓                                             |
+| Element — **Verify Code**                 | —           | ✓                                             |
+| Element — **Grade Result**                | —           | ✓ (needs the **Gradebook** add-on)            |
+| Element — **Co-Instructors**              | —           | ✓ (needs the **Multiple Instructors** add-on) |
+| Download / email certificates to students | ✓           | ✓                                             |
+| Certificate sharing                       | ✓           | ✓                                             |
 
 <Callout>
   {" "}
-  **Free version limit:** With the free plugin you can publish **up to 2** certificate
-  templates. If you try to publish a third, Masteriyo asks you to upgrade. Upgrade
-  to [Masteriyo Pro](https://masteriyo.com/pricing/) for unlimited templates and
-  the new drag-and-drop builder.
+  **Free version limit:** With the free plugin you can publish **up to 2**
+  certificate templates. If you try to publish a third, Masteriyo asks you to
+  upgrade. Upgrade to [Masteriyo Pro](https://masteriyo.com/pricing/) for
+  unlimited templates and the new drag-and-drop builder.
 </Callout>
 
 ---
@@ -314,13 +321,17 @@ Here's what each gives you:
 ## Frequently Asked Questions
 
 **Why does a license popup appear when I click "Add New Certificate"?**
+
 The new builder is a Pro feature. Add or renew your [Masteriyo Pro](https://masteriyo.com/pricing/) license to create certificates with it.
 
 **My certificate won't preview or export.**
+
 The page is probably too large. Lower the width or height (keep it to a normal certificate size) and try again.
 
 **The QR code looks fine in the PDF but had a box around it on screen.**
+
 The downloaded PDF is the final result — the QR code there is clean and scannable.
 
 **I finished a course but didn't get a certificate.**
+
 Make sure the certificate is **published** and attached to that course under **Course > Settings > Select Certificate**.

--- a/250-free-addons/16-certificate-builder-v2.mdx
+++ b/250-free-addons/16-certificate-builder-v2.mdx
@@ -1,0 +1,324 @@
+---
+title: Certificate Builder (New)
+show_child_cards: true
+excerpt: Design beautiful course certificates with the new drag-and-drop Certificate Builder. Pick a template, drop in your text and logo, add smart fields like the student's name, then preview and export as a PDF.
+---
+
+The new Certificate Builder is a visual, drag-and-drop designer for course certificates. You start from a ready-made template (or a blank page), move things around with your mouse, and add "smart fields" that fill in each student's details automatically. When you are happy, you can preview it and export a PDF.
+
+It works like a simple design tool — no code, no Gutenberg blocks. This is different from the older [Classic Certificate Builder](https://docs.masteriyo.com/free-addons/certificate-builder), which uses the WordPress block editor.
+
+<Callout>
+  {" "}
+  **Requirement:** The new builder needs [Masteriyo Pro](https://masteriyo.com/pricing/). The Certificate Builder add-on itself is free, but creating a certificate with the new builder asks for an active Pro license. If your license is missing or expired, a license popup appears when you click **Add New Certificate**.
+</Callout>
+
+---
+
+## Prerequisites
+
+| Requirement | Details |
+| --- | --- |
+| Masteriyo | [Masteriyo Pro](https://masteriyo.com/pricing/) (the new builder is a Pro feature) |
+| Add-on | [Activate the Certificate Builder add-on](https://docs.masteriyo.com/getting-started/activate-masteriyo-addons) from **Masteriyo > Add-ons** |
+
+---
+
+## Opening the Certificate Builder
+
+1. In your WordPress dashboard, go to **Masteriyo > Certificates**.
+2. You will see the certificates screen. This is where all your certificates live.
+
+![The Certificates screen with the certificate list and toolbar](https://img.masteriyo.com/w:auto/h:auto/q:auto/id:dc48369195f3948369655b0425c5e3d9/directUpload/Certificates-list.png)
+
+Here is what the screen offers:
+
+| Area | What it does |
+| --- | --- |
+| **All Certificates / Published / Draft / Trash** | Tabs at the top that filter your certificates by status. Each tab shows a count. |
+| **All / Portrait / Landscape** | Buttons that filter certificates by page shape. |
+| **Search templates…** | A search box to find a certificate by name. |
+| **Add New Certificate** | The button (top-right) to start a new certificate. |
+
+Each certificate shows as a card with a small preview, its name, a **Draft** label if it is unpublished, and how long ago it was edited (for example, "3m ago").
+
+---
+
+## Creating a Certificate
+
+1. Click **Add New Certificate**.
+
+   <Callout>
+     {" "}
+     **Note:** If your Pro license is inactive or expired, a license popup opens here and the next step is blocked. Add or renew your license to continue.
+   </Callout>
+
+2. The **Choose a Template** screen opens. Pick how you want to start:
+
+   - **Create from blank** — start with an empty page.
+   - **A starter template** — pick one of the ready-made designs and customize it.
+
+   ![Choose a Template screen with the blank option and starter templates](https://img.masteriyo.com/w:auto/h:auto/q:auto/id:60148b0bdee6a9ec7bae1631e80ee29e/directUpload/Certificate-templates.png)
+
+3. **If you chose "Create from blank"**, a small **New Project** window asks for the page setup:
+
+   | Option | What to do |
+   | --- | --- |
+   | **Portrait / Landscape** | Choose the page orientation (tall or wide). |
+   | **Width / Height** | Type the page size. |
+   | **Unit** | Choose **in** (inches), **cm**, or **px** (pixels). |
+   | **Paper Size** | Quick presets — Letter, Tabloid, A0–A6, B4, B5, Executive, Folio. Click one to fill in the size for you. |
+
+   ![New Project window with orientation, size, and paper presets](https://img.masteriyo.com/w:auto/h:auto/q:auto/id:979e93f9df6cf0947f9d4fcb2f0fd526/directUpload/New_project_dialoge.png)
+
+   <Callout>
+     {" "}
+     **Tip:** Keep the page a normal certificate size (A4 or Letter works well). Width and height cannot be more than 100 inches, and very large pages can be slow to preview.
+   </Callout>
+
+4. Click **Create**. The certificate opens in the editor, ready to design.
+
+   *(If you picked a starter template instead, it opens straight in the editor with the design already in place.)*
+
+---
+
+## Designing Your Certificate
+
+The editor is where you build the design. It has three main areas:
+
+- **Top bar** — the project title, **Undo / Redo**, a **save status** indicator, **Preview**, **Publish**, and a **⋮** menu (Save to Draft, Export as PDF, Delete design).
+- **Left panel** — four tabs for adding and configuring content: **Elements**, **Library**, **Background**, and **Settings**.
+- **Right panel** — the **Layers** list, showing every item on the page so you can select, reorder, and group them.
+
+![The certificate editor with the left panel, canvas, and Layers panel](https://img.masteriyo.com/w:auto/h:auto/q:auto/id:595262e8d4a748d8a5441bd6f295334c/directUpload/Editor_Overview.png)
+
+<Callout>
+  {" "}
+  **Note:** Each certificate is a **single page**. To change its size or orientation later, use **Settings → Resize Project** (see below).
+</Callout>
+
+### The left panel tabs
+
+| Tab | What it does |
+| --- | --- |
+| **Elements** | Add new items to the page — **Text**, **Image**, **Shape**, **Divider**, and **Smart Fields** (see [Adding Student & Course Details](#adding-student--course-details-smart-fields)). |
+| **Library** | Insert shapes and pictures, and upload images from your computer (they go to your WordPress Media Library). |
+| **Background** | Set the page background. Pick one of the ready-made Masteriyo patterns, or use the **Edit** button above the canvas to add or replace a background image. |
+| **Settings** | Document settings — **Resize Project**, **View**, and the **Pixel Guide** toggle. The title at the top shows the certificate name (click the pencil to rename) and the page size. |
+
+### Adding and arranging elements
+
+1. Open the **Elements** tab and add what you need — Text, Image, Shape, Divider, or a Smart Field.
+2. Drag an element on the page to move it; drag its handles to resize; drag the round handle to rotate.
+3. **Select an element** to reveal its properties, then adjust the basics that apply to it — position and size, color or fill, and (for text) the font, size, alignment, and weight.
+4. Use the **Layers** panel on the right to select and reorder items (drag the handle). Stacking order top-to-bottom in the list matches front-to-back on the page; grouped items appear together as a **Group**. To group or ungroup a selection, use the right-click menu or the keyboard shortcuts below.
+
+### Aligning things precisely (Pixel Guide)
+
+Turn on **Settings → Pixel Guide** to show measurement lines as you move elements. While it's on, **hold Alt** and hover over an element to see its distance from another — handy for lining things up and keeping even spacing.
+
+### Zooming
+
+Use the **zoom control** at the bottom of the canvas to zoom in and out, or hold **Ctrl/⌘** and scroll your mouse wheel (pinch to zoom on a trackpad).
+
+### Saving your work
+
+You don't need a separate "Save" click for every change — the editor saves as you go. Watch the indicator near the top:
+
+| Indicator | Meaning |
+| --- | --- |
+| **Saving…** | Your changes are being saved right now. |
+| **Unsaved changes** | You have edits that are about to be saved. |
+| **Saved** | Everything is saved. |
+
+---
+
+## Keyboard Shortcuts
+
+These shortcuts speed up designing. On a Mac, use **⌘ (Cmd)** wherever **Ctrl** is shown.
+
+| Action | Shortcut |
+| --- | --- |
+| **Editing** | |
+| Undo | `Ctrl + Z` |
+| Redo | `Ctrl + Shift + Z` |
+| Copy | `Ctrl + C` |
+| Paste | `Ctrl + V` |
+| Duplicate | `Ctrl + D` |
+| Select all (on the page) | `Ctrl + A` |
+| Delete selected | `Delete` or `Backspace` |
+| Deselect | `Esc` |
+| Save | `Ctrl + S` |
+| **Move & nudge** | |
+| Move 1 px | Arrow keys (`← ↑ → ↓`) |
+| Move 10 px | `Shift` + arrow keys |
+| **Arrange & layers** | |
+| Bring forward | `Ctrl + ]` |
+| Send backward | `Ctrl + [` |
+| Bring to front | `Ctrl + Alt + ]` |
+| Send to back | `Ctrl + Alt + [` |
+| Group | `Ctrl + G` |
+| Ungroup | `Ctrl + Shift + G` |
+| **Zoom** | |
+| Zoom in | `Ctrl + =` (or `Ctrl + +`) |
+| Zoom out | `Ctrl + -` |
+| Zoom with the mouse | Hold `Ctrl` and scroll (pinch on a trackpad) |
+
+<Callout>
+  {" "}
+  **Tip:** Many of these actions are also on the right-click menu of a selected element — copy, paste, duplicate, delete, layer order, and alignment.
+</Callout>
+
+---
+
+## Adding Student & Course Details (Smart Fields)
+
+Smart fields are placeholders that fill in automatically for each student. For example, instead of typing a name, you drop in the **Student Name** field — and every student sees their own name on their certificate.
+
+In the editor, open the **Masteriyo LMS** group in the left panel and drag the field you want onto the page. In the editor it shows as a placeholder like `{ Student Name }`; on the real certificate it becomes the student's actual name.
+
+| Field | What it shows |
+| --- | --- |
+| **Student Name** (also **First Name** / **Last Name**) | The student's name. |
+| **Course Title** | The name of the completed course. |
+| **Site Name** | Your website's name. |
+| **Completion Date** | The date the student finished the course. |
+| **Start Date** | The date the student started the course. |
+| **Course Duration** | How long the course took. |
+| **Instructor Name** | The course instructor's name. |
+| **Current Date / Current Time / Timestamp** | The date/time the certificate is generated. |
+| **QR Code** *(Pro)* | A scannable code that links to the certificate's verification page. |
+| **Verify Code** *(Pro)* | A unique text code used to verify the certificate. |
+| **Grade Result** *(Pro)* | The student's final grade. *Appears only if the Gradebook add-on is active.* |
+| **Co-Instructors** *(Pro)* | Names of additional instructors. *Appears only if the Multiple Instructors add-on is active.* |
+
+<Callout>
+  {" "}
+  **Note:** You only see the fields that apply to your setup. **Grade Result** needs the **Gradebook** add-on and **Co-Instructors** needs the **Multiple Instructors** add-on before they appear.
+</Callout>
+
+---
+
+## Previewing and Exporting as PDF
+
+To check your design or get a PDF, open the menu (the **⋮** icon) in the editor's top bar:
+
+- **Preview** — opens a PDF preview of the certificate in a new browser tab.
+- **Export as PDF** — opens the certificate as a downloadable PDF in a new tab.
+
+<Callout>
+  {" "}
+  **Tip:** If Preview or Export does nothing, your page may be too large to render. Reduce the width or height and try again.
+</Callout>
+
+---
+
+## Managing Your Certificates
+
+Back on the **Masteriyo > Certificates** screen, each certificate card has a **⋮** menu:
+
+- **Edit** — open it in the editor.
+- **Duplicate** — make a copy to reuse a design.
+- **Move to Trash** — remove it (you can restore it later).
+
+On the **Trash** tab, the menu shows:
+
+- **Restore** — put the certificate back.
+- **Delete Permanently** — remove it for good.
+
+### Working with several at once (bulk actions)
+
+1. Click the checkbox in the toolbar to turn on selection mode.
+2. Tick the certificates you want.
+3. A bar appears at the bottom with the available action — **Move to Trash** (or **Restore** / **Delete Permanently** on the Trash tab).
+
+---
+
+## Giving a Certificate to a Course
+
+A certificate is only awarded once you attach it to a course.
+
+1. Go to **Masteriyo > Courses** and open the course **Builder**.
+2. Open the **Settings** tab.
+3. Turn on **Enable Certificate**.
+4. In **Select Certificate**, search and choose your certificate. Certificates made with the new builder appear under **Certificate V2**; older ones appear under **Classic Certificates**. (Only **published** certificates show up here.)
+5. (Optional) Turn on **Send Certificate via Email** to email it to students after they finish.
+6. (Optional) Turn on **Allow Certificate Sharing** to let students share it from the course page.
+7. **Save** the course.
+
+![Course Settings with Enable Certificate and Select Certificate](https://img.masteriyo.com/w:auto/h:auto/q:auto/id:7736e737e203f4f1f9890ad4e4affc73/directUpload/Assign_Certificate.png)
+
+<Callout>
+  {" "}
+  **Note:** Only **published** certificates appear in the dropdown. If you don't see yours, open it in the editor and publish it first.
+</Callout>
+
+---
+
+## What Students See
+
+Once a student completes the course, they can get their certificate in a few places:
+
+- **Account page → Your Certificates** — each course shows a **Preview** button (opens the certificate) and a **Download Certificate** button (downloads the PDF).
+- **Course completion** — a **Download Certificate** link appears when they finish the course.
+- **Single course page** — if sharing is enabled, a **Share your certificate** button appears.
+
+![The student's Your Certificates page with Preview and Download buttons](https://img.masteriyo.com/w:auto/h:auto/q:auto/id:d9ccc550b3b2475aca77aea871455a9b/directUpload/Course_Instructor.png)
+
+---
+
+## Certificate Settings
+
+You can fine-tune a few things under **Masteriyo > Certificates > Settings**:
+
+| Setting | What it does |
+| --- | --- |
+| **Use Image Absolute Path** | Turn on if images don't show in the certificate. It uses the full image URL instead of a shortened path. |
+| **Use SSL Verify Host** | Turn on if images still don't show. It loads images over HTTPS. |
+| **Install Certificate Fonts** | Installs the extra fonts certificates need. |
+| **Install Custom Fonts** *(Pro)* | Upload your own fonts (a ZIP or font file) to use in your designs. |
+
+---
+
+## Free vs Pro
+
+Masteriyo has **two** certificate builders:
+
+- The **Classic Certificate Builder** (free) — built with the WordPress block editor. See the [Classic Certificate Builder guide](https://docs.masteriyo.com/free-addons/certificate-builder).
+- The **new Certificate Builder** (this guide) — the drag-and-drop designer, which needs **[Masteriyo Pro](https://masteriyo.com/pricing/)**.
+
+Here's what each gives you:
+
+| Capability | Free | Pro |
+| --- | --- | --- |
+| Classic (block editor) certificate builder | ✓ | ✓ |
+| New drag-and-drop builder (this guide) | — | ✓ |
+| Published certificate templates | Up to **2** | Unlimited |
+| Upload custom fonts (**Install Custom Fonts**) | — | ✓ |
+| Smart field — **QR Code** | — | ✓ |
+| Smart field — **Verify Code** | — | ✓ |
+| Smart field — **Grade Result** | — | ✓ (needs the **Gradebook** add-on) |
+| Smart field — **Co-Instructors** | — | ✓ (needs the **Multiple Instructors** add-on) |
+| Download / email certificates to students | ✓ | ✓ |
+| Certificate sharing | ✓ | ✓ |
+
+<Callout>
+  {" "}
+  **Free version limit:** With the free plugin you can publish **up to 2** certificate templates. If you try to publish a third, Masteriyo asks you to upgrade. Upgrade to [Masteriyo Pro](https://masteriyo.com/pricing/) for unlimited templates and the new drag-and-drop builder.
+</Callout>
+
+---
+
+## Frequently Asked Questions
+
+**Why does a license popup appear when I click "Add New Certificate"?**
+The new builder is a Pro feature. Add or renew your [Masteriyo Pro](https://masteriyo.com/pricing/) license to create certificates with it.
+
+**My certificate won't preview or export.**
+The page is probably too large. Lower the width or height (keep it to a normal certificate size) and try again.
+
+**The QR code looks fine in the PDF but had a box around it on screen.**
+The downloaded PDF is the final result — the QR code there is clean and scannable.
+
+**I finished a course but didn't get a certificate.**
+Make sure the certificate is **published** and attached to that course under **Course > Settings > Select Certificate**.

--- a/250-free-addons/16-certificate-builder-v2.mdx
+++ b/250-free-addons/16-certificate-builder-v2.mdx
@@ -1,10 +1,10 @@
 ---
 title: Certificate Builder V2 (New)
 show_child_cards: true
-excerpt: Design beautiful course certificates with the new drag-and-drop Certificate Builder. Pick a template, drop in your text and logo, add smart fields like the student's name, then preview and export as a PDF.
+excerpt: Design beautiful course certificates with the new drag-and-drop Certificate Builder. Pick a template, drop in your text and logo, add elements like the student's name, then preview and export as a PDF.
 ---
 
-The new Certificate Builder is a visual, drag-and-drop designer for course certificates. You start from a ready-made template (or a blank page), move things around with your mouse, and add "smart fields" that fill in each student's details automatically. When you are happy, you can preview it and export a PDF.
+The new Certificate Builder is a visual, drag-and-drop designer for course certificates. You start from a ready-made template (or a blank page), move things around with your mouse, and add elements that fill in each student's details automatically. When you are happy, you can preview it and export a PDF.
 
 It works like a simple design tool — no code, no Gutenberg blocks. This is different from the older [Classic Certificate Builder](https://docs.masteriyo.com/free-addons/certificate-builder), which uses the WordPress block editor.
 
@@ -108,14 +108,14 @@ The editor is where you build the design. It has three main areas:
 
 | Tab            | What it does                                                                                                                                                                         |
 | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Elements**   | Add new items to the page — **Text**, **Image**, **Shape**, **Divider**, and **Smart Fields** (see [Adding Student & Course Details](#adding-student--course-details-smart-fields)). |
+| **Elements**   | Add new items to the page — **Text**, **Image**, **Shape**, **Divider**, and the **Masteriyo LMS** elements that fill in student and course details (see [Adding Student & Course Details](#adding-student--course-details-elements)). |
 | **Library**    | Insert shapes and pictures, and upload images from your computer (they go to your WordPress Media Library).                                                                          |
 | **Background** | Set the page background. Pick one of the ready-made Masteriyo patterns, or use the **Edit** button above the canvas to add or replace a background image.                            |
 | **Settings**   | Document settings — **Resize Project**, **View**, and the **Pixel Guide** toggle. The title at the top shows the certificate name (click the pencil to rename) and the page size.    |
 
 ### Adding and arranging elements
 
-1. Open the **Elements** tab and add what you need — Text, Image, Shape, Divider, or a Smart Field.
+1. Open the **Elements** tab and add what you need — Text, Image, Shape, Divider, or a Masteriyo LMS element.
 2. Drag an element on the page to move it; drag its handles to resize; drag the round handle to rotate.
 3. **Select an element** to reveal its properties, then adjust the basics that apply to it — position and size, color or fill, and (for text) the font, size, alignment, and weight.
 4. Use the **Layers** panel on the right to select and reorder items (drag the handle). Stacking order top-to-bottom in the list matches front-to-back on the page; grouped items appear together as a **Group**. To group or ungroup a selection, use the right-click menu or the keyboard shortcuts below.
@@ -179,11 +179,11 @@ These shortcuts speed up designing. On a Mac, use **⌘ (Cmd)** wherever **Ctrl*
 
 ---
 
-## Adding Student & Course Details (Smart Fields)
+## Adding Student & Course Details (Elements)
 
-Smart fields are placeholders that fill in automatically for each student. For example, instead of typing a name, you drop in the **Student Name** field — and every student sees their own name on their certificate.
+These elements are placeholders that fill in automatically for each student. For example, instead of typing a name, you drop in the **Student Name** element — and every student sees their own name on their certificate.
 
-In the editor, open the **Masteriyo LMS** group in the left panel and drag the field you want onto the page. In the editor it shows as a placeholder like `{ Student Name }`; on the real certificate it becomes the student's actual name.
+In the editor, open the **Masteriyo LMS** group in the left panel and drag the element you want onto the page. In the editor it shows as a placeholder like `{ Student Name }`; on the real certificate it becomes the student's actual name.
 
 | Field                                                  | What it shows                                                                                 |
 | ------------------------------------------------------ | --------------------------------------------------------------------------------------------- |
@@ -307,10 +307,10 @@ Here's what each gives you:
 | New drag-and-drop builder (this guide)         | —           | ✓                                             |
 | Published certificate templates                | Up to **2** | Unlimited                                     |
 | Upload custom fonts (**Install Custom Fonts**) | —           | ✓                                             |
-| Smart field — **QR Code**                      | —           | ✓                                             |
-| Smart field — **Verify Code**                  | —           | ✓                                             |
-| Smart field — **Grade Result**                 | —           | ✓ (needs the **Gradebook** add-on)            |
-| Smart field — **Co-Instructors**               | —           | ✓ (needs the **Multiple Instructors** add-on) |
+| Element — **QR Code**                          | —           | ✓                                             |
+| Element — **Verify Code**                      | —           | ✓                                             |
+| Element — **Grade Result**                     | —           | ✓ (needs the **Gradebook** add-on)            |
+| Element — **Co-Instructors**                   | —           | ✓ (needs the **Multiple Instructors** add-on) |
 | Download / email certificates to students      | ✓           | ✓                                             |
 | Certificate sharing                            | ✓           | ✓                                             |
 

--- a/250-free-addons/16-certificate-builder-v2.mdx
+++ b/250-free-addons/16-certificate-builder-v2.mdx
@@ -108,7 +108,7 @@ The editor is where you build the design. It has three main areas:
 
 | Tab            | What it does                                                                                                                                                                         |
 | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Elements**   | Add new items to the page — **Text**, **Image**, **Shape**, **Divider**, and the **Masteriyo LMS** elements that fill in student and course details (see [Adding Student & Course Details](#adding-student--course-details-elements)). |
+| **Elements**   | Add new items to the page — **Text**, **Image**, **Shape**, **Divider**, and the **Masteriyo LMS** elements that fill in student and course details (see [Adding Student & Course Details (Elements)](#adding-student--course-details-elements)). |
 | **Library**    | Insert shapes and pictures, and upload images from your computer (they go to your WordPress Media Library).                                                                          |
 | **Background** | Set the page background. Pick one of the ready-made Masteriyo patterns, or use the **Edit** button above the canvas to add or replace a background image.                            |
 | **Settings**   | Document settings — **Resize Project**, **View**, and the **Pixel Guide** toggle. The title at the top shows the certificate name (click the pencil to rename) and the page size.    |

--- a/250-free-addons/16-certificate-builder-v2.mdx
+++ b/250-free-addons/16-certificate-builder-v2.mdx
@@ -1,5 +1,5 @@
 ---
-title: Certificate Builder (New)
+title: Certificate Builder V2 (New)
 show_child_cards: true
 excerpt: Design beautiful course certificates with the new drag-and-drop Certificate Builder. Pick a template, drop in your text and logo, add smart fields like the student's name, then preview and export as a PDF.
 ---
@@ -10,17 +10,20 @@ It works like a simple design tool — no code, no Gutenberg blocks. This is dif
 
 <Callout>
   {" "}
-  **Requirement:** The new builder needs [Masteriyo Pro](https://masteriyo.com/pricing/). The Certificate Builder add-on itself is free, but creating a certificate with the new builder asks for an active Pro license. If your license is missing or expired, a license popup appears when you click **Add New Certificate**.
+  **Requirement:** The new builder needs [Masteriyo Pro](https://masteriyo.com/pricing/).
+  The Certificate Builder add-on itself is free, but creating a certificate with
+  the new builder asks for an active Pro license. If your license is missing or expired,
+  a license popup appears when you click **Add New Certificate**.
 </Callout>
 
 ---
 
 ## Prerequisites
 
-| Requirement | Details |
-| --- | --- |
-| Masteriyo | [Masteriyo Pro](https://masteriyo.com/pricing/) (the new builder is a Pro feature) |
-| Add-on | [Activate the Certificate Builder add-on](https://docs.masteriyo.com/getting-started/activate-masteriyo-addons) from **Masteriyo > Add-ons** |
+| Requirement | Details                                                                                                                                      |
+| ----------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| Masteriyo   | [Masteriyo](https://masteriyo.com/pricing/)                                                                                                  |
+| Add-on      | [Activate the Certificate Builder add-on](https://docs.masteriyo.com/getting-started/activate-masteriyo-addons) from **Masteriyo > Add-ons** |
 
 ---
 
@@ -33,12 +36,12 @@ It works like a simple design tool — no code, no Gutenberg blocks. This is dif
 
 Here is what the screen offers:
 
-| Area | What it does |
-| --- | --- |
+| Area                                             | What it does                                                                     |
+| ------------------------------------------------ | -------------------------------------------------------------------------------- |
 | **All Certificates / Published / Draft / Trash** | Tabs at the top that filter your certificates by status. Each tab shows a count. |
-| **All / Portrait / Landscape** | Buttons that filter certificates by page shape. |
-| **Search templates…** | A search box to find a certificate by name. |
-| **Add New Certificate** | The button (top-right) to start a new certificate. |
+| **All / Portrait / Landscape**                   | Buttons that filter certificates by page shape.                                  |
+| **Search templates…**                            | A search box to find a certificate by name.                                      |
+| **Add New Certificate**                          | The button (top-right) to start a new certificate.                               |
 
 Each certificate shows as a card with a small preview, its name, a **Draft** label if it is unpublished, and how long ago it was edited (for example, "3m ago").
 
@@ -50,7 +53,8 @@ Each certificate shows as a card with a small preview, its name, a **Draft** lab
 
    <Callout>
      {" "}
-     **Note:** If your Pro license is inactive or expired, a license popup opens here and the next step is blocked. Add or renew your license to continue.
+     **Note:** If your Pro license is inactive or expired, a license popup opens
+     here and the next step is blocked. Add or renew your license to continue.
    </Callout>
 
 2. The **Choose a Template** screen opens. Pick how you want to start:
@@ -62,23 +66,25 @@ Each certificate shows as a card with a small preview, its name, a **Draft** lab
 
 3. **If you chose "Create from blank"**, a small **New Project** window asks for the page setup:
 
-   | Option | What to do |
-   | --- | --- |
-   | **Portrait / Landscape** | Choose the page orientation (tall or wide). |
-   | **Width / Height** | Type the page size. |
-   | **Unit** | Choose **in** (inches), **cm**, or **px** (pixels). |
-   | **Paper Size** | Quick presets — Letter, Tabloid, A0–A6, B4, B5, Executive, Folio. Click one to fill in the size for you. |
+   | Option                   | What to do                                                                                               |
+   | ------------------------ | -------------------------------------------------------------------------------------------------------- |
+   | **Portrait / Landscape** | Choose the page orientation (tall or wide).                                                              |
+   | **Width / Height**       | Type the page size.                                                                                      |
+   | **Unit**                 | Choose **in** (inches), **cm**, or **px** (pixels).                                                      |
+   | **Paper Size**           | Quick presets — Letter, Tabloid, A0–A6, B4, B5, Executive, Folio. Click one to fill in the size for you. |
 
    ![New Project window with orientation, size, and paper presets](https://img.masteriyo.com/w:auto/h:auto/q:auto/id:979e93f9df6cf0947f9d4fcb2f0fd526/directUpload/New_project_dialoge.png)
 
    <Callout>
      {" "}
-     **Tip:** Keep the page a normal certificate size (A4 or Letter works well). Width and height cannot be more than 100 inches, and very large pages can be slow to preview.
+     **Tip:** Keep the page a normal certificate size (A4 or Letter works well).
+     Width and height cannot be more than 100 inches, and very large pages can be
+     slow to preview.
    </Callout>
 
 4. Click **Create**. The certificate opens in the editor, ready to design.
 
-   *(If you picked a starter template instead, it opens straight in the editor with the design already in place.)*
+   _(If you picked a starter template instead, it opens straight in the editor with the design already in place.)_
 
 ---
 
@@ -94,17 +100,18 @@ The editor is where you build the design. It has three main areas:
 
 <Callout>
   {" "}
-  **Note:** Each certificate is a **single page**. To change its size or orientation later, use **Settings → Resize Project** (see below).
+  **Note:** Each certificate is a **single page**. To change its size or orientation
+  later, use **Settings → Resize Project** (see below).
 </Callout>
 
 ### The left panel tabs
 
-| Tab | What it does |
-| --- | --- |
-| **Elements** | Add new items to the page — **Text**, **Image**, **Shape**, **Divider**, and **Smart Fields** (see [Adding Student & Course Details](#adding-student--course-details-smart-fields)). |
-| **Library** | Insert shapes and pictures, and upload images from your computer (they go to your WordPress Media Library). |
-| **Background** | Set the page background. Pick one of the ready-made Masteriyo patterns, or use the **Edit** button above the canvas to add or replace a background image. |
-| **Settings** | Document settings — **Resize Project**, **View**, and the **Pixel Guide** toggle. The title at the top shows the certificate name (click the pencil to rename) and the page size. |
+| Tab            | What it does                                                                                                                                                                         |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Elements**   | Add new items to the page — **Text**, **Image**, **Shape**, **Divider**, and **Smart Fields** (see [Adding Student & Course Details](#adding-student--course-details-smart-fields)). |
+| **Library**    | Insert shapes and pictures, and upload images from your computer (they go to your WordPress Media Library).                                                                          |
+| **Background** | Set the page background. Pick one of the ready-made Masteriyo patterns, or use the **Edit** button above the canvas to add or replace a background image.                            |
+| **Settings**   | Document settings — **Resize Project**, **View**, and the **Pixel Guide** toggle. The title at the top shows the certificate name (click the pencil to rename) and the page size.    |
 
 ### Adding and arranging elements
 
@@ -125,11 +132,11 @@ Use the **zoom control** at the bottom of the canvas to zoom in and out, or hold
 
 You don't need a separate "Save" click for every change — the editor saves as you go. Watch the indicator near the top:
 
-| Indicator | Meaning |
-| --- | --- |
-| **Saving…** | Your changes are being saved right now. |
+| Indicator           | Meaning                                    |
+| ------------------- | ------------------------------------------ |
+| **Saving…**         | Your changes are being saved right now.    |
 | **Unsaved changes** | You have edits that are about to be saved. |
-| **Saved** | Everything is saved. |
+| **Saved**           | Everything is saved.                       |
 
 ---
 
@@ -137,36 +144,37 @@ You don't need a separate "Save" click for every change — the editor saves as 
 
 These shortcuts speed up designing. On a Mac, use **⌘ (Cmd)** wherever **Ctrl** is shown.
 
-| Action | Shortcut |
-| --- | --- |
-| **Editing** | |
-| Undo | `Ctrl + Z` |
-| Redo | `Ctrl + Shift + Z` |
-| Copy | `Ctrl + C` |
-| Paste | `Ctrl + V` |
-| Duplicate | `Ctrl + D` |
-| Select all (on the page) | `Ctrl + A` |
-| Delete selected | `Delete` or `Backspace` |
-| Deselect | `Esc` |
-| Save | `Ctrl + S` |
-| **Move & nudge** | |
-| Move 1 px | Arrow keys (`← ↑ → ↓`) |
-| Move 10 px | `Shift` + arrow keys |
-| **Arrange & layers** | |
-| Bring forward | `Ctrl + ]` |
-| Send backward | `Ctrl + [` |
-| Bring to front | `Ctrl + Alt + ]` |
-| Send to back | `Ctrl + Alt + [` |
-| Group | `Ctrl + G` |
-| Ungroup | `Ctrl + Shift + G` |
-| **Zoom** | |
-| Zoom in | `Ctrl + =` (or `Ctrl + +`) |
-| Zoom out | `Ctrl + -` |
-| Zoom with the mouse | Hold `Ctrl` and scroll (pinch on a trackpad) |
+| Action                   | Shortcut                                     |
+| ------------------------ | -------------------------------------------- |
+| **Editing**              |                                              |
+| Undo                     | `Ctrl + Z`                                   |
+| Redo                     | `Ctrl + Shift + Z`                           |
+| Copy                     | `Ctrl + C`                                   |
+| Paste                    | `Ctrl + V`                                   |
+| Duplicate                | `Ctrl + D`                                   |
+| Select all (on the page) | `Ctrl + A`                                   |
+| Delete selected          | `Delete` or `Backspace`                      |
+| Deselect                 | `Esc`                                        |
+| Save                     | `Ctrl + S`                                   |
+| **Move & nudge**         |                                              |
+| Move 1 px                | Arrow keys (`← ↑ → ↓`)                       |
+| Move 10 px               | `Shift` + arrow keys                         |
+| **Arrange & layers**     |                                              |
+| Bring forward            | `Ctrl + ]`                                   |
+| Send backward            | `Ctrl + [`                                   |
+| Bring to front           | `Ctrl + Alt + ]`                             |
+| Send to back             | `Ctrl + Alt + [`                             |
+| Group                    | `Ctrl + G`                                   |
+| Ungroup                  | `Ctrl + Shift + G`                           |
+| **Zoom**                 |                                              |
+| Zoom in                  | `Ctrl + =` (or `Ctrl + +`)                   |
+| Zoom out                 | `Ctrl + -`                                   |
+| Zoom with the mouse      | Hold `Ctrl` and scroll (pinch on a trackpad) |
 
 <Callout>
   {" "}
-  **Tip:** Many of these actions are also on the right-click menu of a selected element — copy, paste, duplicate, delete, layer order, and alignment.
+  **Tip:** Many of these actions are also on the right-click menu of a selected element
+  — copy, paste, duplicate, delete, layer order, and alignment.
 </Callout>
 
 ---
@@ -177,24 +185,26 @@ Smart fields are placeholders that fill in automatically for each student. For e
 
 In the editor, open the **Masteriyo LMS** group in the left panel and drag the field you want onto the page. In the editor it shows as a placeholder like `{ Student Name }`; on the real certificate it becomes the student's actual name.
 
-| Field | What it shows |
-| --- | --- |
-| **Student Name** (also **First Name** / **Last Name**) | The student's name. |
-| **Course Title** | The name of the completed course. |
-| **Site Name** | Your website's name. |
-| **Completion Date** | The date the student finished the course. |
-| **Start Date** | The date the student started the course. |
-| **Course Duration** | How long the course took. |
-| **Instructor Name** | The course instructor's name. |
-| **Current Date / Current Time / Timestamp** | The date/time the certificate is generated. |
-| **QR Code** *(Pro)* | A scannable code that links to the certificate's verification page. |
-| **Verify Code** *(Pro)* | A unique text code used to verify the certificate. |
-| **Grade Result** *(Pro)* | The student's final grade. *Appears only if the Gradebook add-on is active.* |
-| **Co-Instructors** *(Pro)* | Names of additional instructors. *Appears only if the Multiple Instructors add-on is active.* |
+| Field                                                  | What it shows                                                                                 |
+| ------------------------------------------------------ | --------------------------------------------------------------------------------------------- |
+| **Student Name** (also **First Name** / **Last Name**) | The student's name.                                                                           |
+| **Course Title**                                       | The name of the completed course.                                                             |
+| **Site Name**                                          | Your website's name.                                                                          |
+| **Completion Date**                                    | The date the student finished the course.                                                     |
+| **Start Date**                                         | The date the student started the course.                                                      |
+| **Course Duration**                                    | How long the course took.                                                                     |
+| **Instructor Name**                                    | The course instructor's name.                                                                 |
+| **Current Date / Current Time / Timestamp**            | The date/time the certificate is generated.                                                   |
+| **QR Code** <ProBadge size="xs" />                                    | A scannable code that links to the certificate's verification page.                           |
+| **Verify Code** <ProBadge size="xs" />                                | A unique text code used to verify the certificate.                                            |
+| **Grade Result** <ProBadge size="xs" />                               | The student's final grade. _Appears only if the Gradebook add-on is active._                  |
+| **Co-Instructors** <ProBadge size="xs" />                             | Names of additional instructors. _Appears only if the Multiple Instructors add-on is active._ |
 
 <Callout>
   {" "}
-  **Note:** You only see the fields that apply to your setup. **Grade Result** needs the **Gradebook** add-on and **Co-Instructors** needs the **Multiple Instructors** add-on before they appear.
+  **Note:** You only see the fields that apply to your setup. **Grade Result** needs
+  the **Gradebook** add-on and **Co-Instructors** needs the **Multiple Instructors**
+  add-on before they appear.
 </Callout>
 
 ---
@@ -208,7 +218,8 @@ To check your design or get a PDF, open the menu (the **⋮** icon) in the edito
 
 <Callout>
   {" "}
-  **Tip:** If Preview or Export does nothing, your page may be too large to render. Reduce the width or height and try again.
+  **Tip:** If Preview or Export does nothing, your page may be too large to render.
+  Reduce the width or height and try again.
 </Callout>
 
 ---
@@ -250,7 +261,8 @@ A certificate is only awarded once you attach it to a course.
 
 <Callout>
   {" "}
-  **Note:** Only **published** certificates appear in the dropdown. If you don't see yours, open it in the editor and publish it first.
+  **Note:** Only **published** certificates appear in the dropdown. If you don't
+  see yours, open it in the editor and publish it first.
 </Callout>
 
 ---
@@ -271,12 +283,12 @@ Once a student completes the course, they can get their certificate in a few pla
 
 You can fine-tune a few things under **Masteriyo > Certificates > Settings**:
 
-| Setting | What it does |
-| --- | --- |
-| **Use Image Absolute Path** | Turn on if images don't show in the certificate. It uses the full image URL instead of a shortened path. |
-| **Use SSL Verify Host** | Turn on if images still don't show. It loads images over HTTPS. |
-| **Install Certificate Fonts** | Installs the extra fonts certificates need. |
-| **Install Custom Fonts** *(Pro)* | Upload your own fonts (a ZIP or font file) to use in your designs. |
+| Setting                          | What it does                                                                                             |
+| -------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| **Use Image Absolute Path**      | Turn on if images don't show in the certificate. It uses the full image URL instead of a shortened path. |
+| **Use SSL Verify Host**          | Turn on if images still don't show. It loads images over HTTPS.                                          |
+| **Install Certificate Fonts**    | Installs the extra fonts certificates need.                                                              |
+| **Install Custom Fonts** <ProBadge size="xs" /> | Upload your own fonts (a ZIP or font file) to use in your designs.                                       |
 
 ---
 
@@ -289,22 +301,25 @@ Masteriyo has **two** certificate builders:
 
 Here's what each gives you:
 
-| Capability | Free | Pro |
-| --- | --- | --- |
-| Classic (block editor) certificate builder | ✓ | ✓ |
-| New drag-and-drop builder (this guide) | — | ✓ |
-| Published certificate templates | Up to **2** | Unlimited |
-| Upload custom fonts (**Install Custom Fonts**) | — | ✓ |
-| Smart field — **QR Code** | — | ✓ |
-| Smart field — **Verify Code** | — | ✓ |
-| Smart field — **Grade Result** | — | ✓ (needs the **Gradebook** add-on) |
-| Smart field — **Co-Instructors** | — | ✓ (needs the **Multiple Instructors** add-on) |
-| Download / email certificates to students | ✓ | ✓ |
-| Certificate sharing | ✓ | ✓ |
+| Capability                                     | Free        | Pro                                           |
+| ---------------------------------------------- | ----------- | --------------------------------------------- |
+| Classic (block editor) certificate builder     | ✓           | ✓                                             |
+| New drag-and-drop builder (this guide)         | —           | ✓                                             |
+| Published certificate templates                | Up to **2** | Unlimited                                     |
+| Upload custom fonts (**Install Custom Fonts**) | —           | ✓                                             |
+| Smart field — **QR Code**                      | —           | ✓                                             |
+| Smart field — **Verify Code**                  | —           | ✓                                             |
+| Smart field — **Grade Result**                 | —           | ✓ (needs the **Gradebook** add-on)            |
+| Smart field — **Co-Instructors**               | —           | ✓ (needs the **Multiple Instructors** add-on) |
+| Download / email certificates to students      | ✓           | ✓                                             |
+| Certificate sharing                            | ✓           | ✓                                             |
 
 <Callout>
   {" "}
-  **Free version limit:** With the free plugin you can publish **up to 2** certificate templates. If you try to publish a third, Masteriyo asks you to upgrade. Upgrade to [Masteriyo Pro](https://masteriyo.com/pricing/) for unlimited templates and the new drag-and-drop builder.
+  **Free version limit:** With the free plugin you can publish **up to 2** certificate
+  templates. If you try to publish a third, Masteriyo asks you to upgrade. Upgrade
+  to [Masteriyo Pro](https://masteriyo.com/pricing/) for unlimited templates and
+  the new drag-and-drop builder.
 </Callout>
 
 ---

--- a/250-free-addons/16-certificate-builder-v2.mdx
+++ b/250-free-addons/16-certificate-builder-v2.mdx
@@ -6,7 +6,7 @@ excerpt: Design beautiful course certificates with the new drag-and-drop Certifi
 
 The new Certificate Builder is a visual, drag-and-drop designer for course certificates. You start from a ready-made template (or a blank page), move things around with your mouse, and add elements that fill in each student's details automatically. When you are happy, you can preview it and export a PDF.
 
-It works like a simple design tool — no code, no Gutenberg blocks. This is different from the older [Classic Certificate Builder](https://docs.masteriyo.com/free-addons/certificate-builder), which uses the WordPress block editor.
+It works like a simple design tool — no code needed. This is different from the older [Classic Certificate Builder](https://docs.masteriyo.com/free-addons/certificate-builder).
 
 <Callout>
   {" "}
@@ -179,13 +179,13 @@ These shortcuts speed up designing. On a Mac, use **⌘ (Cmd)** wherever **Ctrl*
 
 ---
 
-## Adding Student & Course Details (Elements)
+## AddingElements
 
 These elements are placeholders that fill in automatically for each student. For example, instead of typing a name, you drop in the **Student Name** element — and every student sees their own name on their certificate.
 
 In the editor, open the **Masteriyo LMS** group in the left panel and drag the element you want onto the page. In the editor it shows as a placeholder like `{ Student Name }`; on the real certificate it becomes the student's actual name.
 
-| Field                                                  | What it shows                                                                                 |
+| Elements                                                | What it shows                                                                                 |
 | ------------------------------------------------------ | --------------------------------------------------------------------------------------------- |
 | **Student Name** (also **First Name** / **Last Name**) | The student's name.                                                                           |
 | **Course Title**                                       | The name of the completed course.                                                             |
@@ -279,31 +279,18 @@ Once a student completes the course, they can get their certificate in a few pla
 
 ---
 
-## Certificate Settings
-
-You can fine-tune a few things under **Masteriyo > Certificates > Settings**:
-
-| Setting                          | What it does                                                                                             |
-| -------------------------------- | -------------------------------------------------------------------------------------------------------- |
-| **Use Image Absolute Path**      | Turn on if images don't show in the certificate. It uses the full image URL instead of a shortened path. |
-| **Use SSL Verify Host**          | Turn on if images still don't show. It loads images over HTTPS.                                          |
-| **Install Certificate Fonts**    | Installs the extra fonts certificates need.                                                              |
-| **Install Custom Fonts** <ProBadge size="xs" /> | Upload your own fonts (a ZIP or font file) to use in your designs.                                       |
-
----
-
 ## Free vs Pro
 
 Masteriyo has **two** certificate builders:
 
-- The **Classic Certificate Builder** (free) — built with the WordPress block editor. See the [Classic Certificate Builder guide](https://docs.masteriyo.com/free-addons/certificate-builder).
+- The **Classic Certificate Builder** (free) — the original certificate builder. See the [Classic Certificate Builder guide](https://docs.masteriyo.com/free-addons/certificate-builder).
 - The **new Certificate Builder** (this guide) — the drag-and-drop designer, which needs **[Masteriyo Pro](https://masteriyo.com/pricing/)**.
 
 Here's what each gives you:
 
 | Capability                                     | Free        | Pro                                           |
 | ---------------------------------------------- | ----------- | --------------------------------------------- |
-| Classic (block editor) certificate builder     | ✓           | ✓                                             |
+| Classic Certificate Builder                    | ✓           | ✓                                             |
 | New drag-and-drop builder (this guide)         | —           | ✓                                             |
 | Published certificate templates                | Up to **2** | Unlimited                                     |
 | Upload custom fonts (**Install Custom Fonts**) | —           | ✓                                             |


### PR DESCRIPTION
## Summary

Adds a complete documentation page for the **new drag-and-drop Certificate Builder ("Certificate V2")** at `250-free-addons/16-certificate-builder-v2.mdx`.

The page is written strictly against what the Masteriyo certificate integration actually exposes — generic PDFDraft-engine features that Masteriyo disables (Tables, Date element, WP Data Fields, Charts, multi-page/Pages tab, Templates panel, Version history, Copy Shortcode) are intentionally **not** documented.

## What's covered

- **Opening & creating a certificate** — Certificates screen, Choose a Template, the New Project dialog (orientation, size, paper presets).
- **Designing your certificate** — the three editor areas (top bar, left panel, Layers panel), the four left-panel tabs (**Elements, Library, Background, Settings**), adding/arranging elements (Text, Image, Shape, Divider, Smart Fields), the **Pixel Guide**, and zooming. Notes that each certificate is a **single page**.
- **Keyboard Shortcuts** — full table (undo/redo, copy/paste, duplicate, move & nudge, group/ungroup, layer ordering, zoom, delete, deselect), with the Mac ⌘ note.
- **Smart Fields** — full list, with **QR Code / Verify Code / Grade Result / Co-Instructors** marked **Pro** (and the Gradebook / Multiple Instructors add-on dependencies).
- **Preview & Export as PDF**, **Managing certificates** (incl. bulk actions), **Assigning a certificate to a course**, and **What students see**.
- **Free vs Pro** — dedicated comparison section: the new builder requires Pro, the free classic builder is capped at **2 published templates**, and custom fonts + the Pro smart fields.
- **Certificate Settings** and an **FAQ**.

## Screenshots

Six screenshots are included for the key flows (Certificates list, template chooser, New Project dialog, editor overview, assigning to a course, and the student view). The detail sections (element controls, Pixel Guide, zoom) are intentionally text-only.

## Notes

- Verified: balanced `<Callout>` tags and a working in-page anchor link. No build script exists in the docs repo, so the page was verified by inspection.
