### PR TITLE
Docs: Analytics Dashboard 

### DIFF
--- a/100-getting-started/420-analytics-dashboard.mdx
+++ b/100-getting-started/420-analytics-dashboard.mdx
@@ -1,0 +1,162 @@
+---
+title: Analytics Dashboard
+excerpt: See how your courses are performing at a glance — enrollments, students, content counts, and more — with metric cards, an enrollment chart, date filters, and printing.
+---
+
+The **Analytics Dashboard** is the first screen you see in Masteriyo. It gives you an at-a-glance view of how your site is doing — how many courses, students, and enrollments you have, plus an enrollment trend over time. You can switch the metrics shown, change the date range, focus on a single course, and print the view.
+
+<Callout>
+  {" "}
+  **Location:** Masteriyo > Dashboard
+</Callout>
+
+<video width="100%" controls loop muted autoPlay playsInline>
+  <source
+    src="https://img.masteriyo.com/files/id:671dc6abca9e93cbc0e429330500bcc4/directUpload/Analytics_.webm"
+    type="video/webm"
+  />
+</video>
+
+---
+
+## Metric cards
+
+The top of the dashboard shows **four metric cards** — each one a single number, like **Total Students** or **Total Enrolled**. By default they show **Total Enrolled**, **Total Courses**, **Total Students**, and **Total Lessons**. You can change what any card shows: click the card's title to open a dropdown, where metrics are organized into groups, then pick the one you want.
+
+In the free version these metrics are available:
+
+| Group          | Metrics                                                            |
+| -------------- | ----------------------------------------------------------------- |
+| **Content**    | Total Courses, Total Lessons, Total Quizzes, Total Questions      |
+| **People**     | Total Enrolled, Total Students, Total Instructors                 |
+| **Engagement** | Total Q&A, Total Reviews                                           |
+
+<Callout>
+  {" "}
+  **Note:** A **Sales** group (Total Earnings, Total Refunds, Total Discounts,
+  Total Orders, Net Revenue, Avg. Order Value) also appears in the dropdown, but
+  those metrics need <ProBadge size="xs" />. They show with a lock until you
+  upgrade.
+</Callout>
+
+![The metric dropdown with the locked Sales group](https://img.masteriyo.com/w:auto/h:auto/q:auto/id:61172f3c50f3a217c445239510680753/directUpload/MetricLock.png)
+
+---
+
+## The enrollment chart
+
+Below the cards is the **Enrollment** chart — it plots **Students Enrolled** over the selected date range so you can spot trends. Use the toggle to switch between a **line** and a **bar** view.
+
+<Callout>
+  {" "}
+  **Note:** Other chart types — Sales, Subscriptions, Learning Activity,
+  Engagement, Instructor Earnings, and Popular Courses — appear here too, but
+  they're <ProBadge size="xs" /> and show locked with an "Upgrade to Pro"
+  overlay.
+</Callout>
+
+---
+
+## Filtering your data
+
+Two controls in the toolbar change what the cards and chart show:
+
+### Date range
+
+Click the date control to pick a period. The presets are:
+
+| Preset                                  | What it covers                          |
+| --------------------------------------- | --------------------------------------- |
+| **Today**                               | The current day.                        |
+| **Last 7 days** / **Last 14 days**      | The last 1–2 weeks.                      |
+| **Last 30 days** _(default)_            | The last month.                         |
+| **Last 3 Months** / **Last 12 Months**  | The last quarter / year.                |
+| **Month to Date** / **Quarter to Date** | From the start of this month / quarter. |
+| **Year to Date**                        | From January 1 of this year.            |
+| **All Time**                            | Everything on record.                   |
+
+You can also pick a **custom range** on the calendar (you can't select a date in the future).
+
+### Course filter
+
+Use the course filter to focus the whole dashboard on one course. It defaults to **All** courses; start typing to search for a specific one. Only published courses appear.
+
+---
+
+## Printing or saving as PDF
+
+Click **Print** in the toolbar to print the current dashboard — or use your browser's "Save as PDF" option in the print dialog to keep a copy. Print is the only export option; there is no separate CSV/PDF download.
+
+<Callout>
+  {" "}
+  **Tip:** An **Updating…** badge appears briefly while the dashboard refreshes
+  its numbers — the data is close to real time, so recent activity shows up
+  quickly.
+</Callout>
+
+---
+
+## Who sees what
+
+What appears on the dashboard depends on the user's role:
+
+- **Administrators and managers** see data for **all** courses on the site.
+- **Instructors** see data for **only their own** courses.
+
+---
+
+## Free vs Pro
+
+The free dashboard covers the essentials. **[Masteriyo Pro](https://masteriyo.com/pricing/)** unlocks the sales metrics, every chart, comparisons, and deeper reports.
+
+![The Pro Analytics Dashboard with sales metrics and charts](https://img.masteriyo.com/w:auto/h:auto/q:auto/id:2a385b45cdb421877f9e0f04f975cd3b/directUpload/Revenue.png)
+
+| Capability                                                     | Free | Pro |
+| -------------------------------------------------------------- | ---- | --- |
+| Content / People / Engagement metrics                          | ✓    | ✓   |
+| Enrollment chart                                               | ✓    | ✓   |
+| Date range & course filter                                     | ✓    | ✓   |
+| Print / save as PDF                                            | ✓    | ✓   |
+| **Sales metrics** (earnings, refunds, orders, net revenue, AOV) | —    | ✓   |
+| **All charts** (Sales, Subscriptions, Learning Activity, etc.) | —    | ✓   |
+| **Period-over-period comparison** (▲/▼ % change)               | —    | ✓   |
+| **Customizable dashboard** (add / remove / reorder, saved)     | —    | ✓   |
+| **Scope & bundle filters** (All / Courses / Bundles)           | —    | ✓   |
+| **Per-course, student & instructor reports + commission**      | —    | ✓   |
+
+<Callout>
+  {" "}
+  **Note:** Some Pro metrics depend on their add-ons — for example **Total
+  Certificates** (Certificate), **Total Assignments** (Assignment), **Total
+  Groups** (Group Courses), and **Bundles Sold** (Course Bundle).
+</Callout>
+
+---
+
+## Per-course analytics <ProBadge size="xs" />
+
+Beyond the site-wide overview, Masteriyo Pro lets you drill into a **single course**. The **Courses** analytics view lists every course with its key numbers (enrollments, revenue, rating), and from there you can open an **individual course report** showing that course's metrics, enrolled students and their progress, and a commission (instructor/admin) breakdown.
+
+You can also open a course's report directly from **Masteriyo > Courses** — click the three dots on a course and choose **Reports**.
+
+For the full walkthrough (with screenshots), see [Advanced Analytics for Courses](https://docs.masteriyo.com/course-creation/course-analytics).
+
+---
+
+## Frequently Asked Questions
+
+**Why don't I see sales or revenue numbers?**
+
+The Sales metrics and charts are a Pro feature. Upgrade to [Masteriyo Pro](https://masteriyo.com/pricing/) to unlock them.
+
+**Why is a chart locked with an "Upgrade to Pro" overlay?**
+
+Only the Enrollment chart is in the free version. The other chart types are Pro.
+
+**As an instructor, why do I only see some of the data?**
+
+Instructors see analytics for their own courses only. Administrators and managers see data for all courses.
+
+**The numbers don't match what I expected.**
+
+Check the **date range** and the **course filter** at the top — the cards and chart only reflect the selected period and course. Data updates quickly but may take a moment to refresh (you'll see an **Updating…** badge).

--- a/100-getting-started/420-analytics-dashboard.mdx
+++ b/100-getting-started/420-analytics-dashboard.mdx
@@ -5,10 +5,7 @@ excerpt: See how your courses are performing at a glance — enrollments, studen
 
 The **Analytics Dashboard** is the first screen you see in Masteriyo. It gives you an at-a-glance view of how your site is doing — how many courses, students, and enrollments you have, plus an enrollment trend over time. You can switch the metrics shown, change the date range, focus on a single course, and print the view.
 
-<Callout>
-  {" "}
-  **Location:** Masteriyo > Dashboard
-</Callout>
+<Callout> **Location:** Masteriyo > Dashboard</Callout>
 
 <video width="100%" controls loop muted autoPlay playsInline>
   <source
@@ -25,18 +22,17 @@ The top of the dashboard shows **four metric cards** — each one a single numbe
 
 In the free version these metrics are available:
 
-| Group          | Metrics                                                            |
-| -------------- | ----------------------------------------------------------------- |
-| **Content**    | Total Courses, Total Lessons, Total Quizzes, Total Questions      |
-| **People**     | Total Enrolled, Total Students, Total Instructors                 |
-| **Engagement** | Total Q&A, Total Reviews                                           |
+| Group          | Metrics                                                      |
+| -------------- | ------------------------------------------------------------ |
+| **Content**    | Total Courses, Total Lessons, Total Quizzes, Total Questions |
+| **People**     | Total Enrolled, Total Students, Total Instructors            |
+| **Engagement** | Total Q&A, Total Reviews                                     |
 
 <Callout>
   {" "}
-  **Note:** A **Sales** group (Total Earnings, Total Refunds, Total Discounts,
-  Total Orders, Net Revenue, Avg. Order Value) also appears in the dropdown, but
-  those metrics need <ProBadge size="xs" />. They show with a lock until you
-  upgrade.
+  **Note:** A **Sales** group (Total Earnings, Total Refunds, Total Discounts, Total
+  Orders, Net Revenue, Avg. Order Value) also appears in the dropdown, but those
+  metrics need PRO They show with a lock until you upgrade.
 </Callout>
 
 ![The metric dropdown with the locked Sales group](https://img.masteriyo.com/w:auto/h:auto/q:auto/id:61172f3c50f3a217c445239510680753/directUpload/MetricLock.png)
@@ -49,10 +45,9 @@ Below the cards is the **Enrollment** chart — it plots **Students Enrolled** o
 
 <Callout>
   {" "}
-  **Note:** Other chart types — Sales, Subscriptions, Learning Activity,
-  Engagement, Instructor Earnings, and Popular Courses — appear here too, but
-  they're <ProBadge size="xs" /> and show locked with an "Upgrade to Pro"
-  overlay.
+  **Note:** Other chart types — Sales, Subscriptions, Learning Activity, Engagement,
+  Instructor Earnings, and Popular Courses — appear here too, but they're PRO and
+  show locked with an "Upgrade to Pro" overlay.
 </Callout>
 
 ---
@@ -68,7 +63,7 @@ Click the date control to pick a period. The presets are:
 | Preset                                  | What it covers                          |
 | --------------------------------------- | --------------------------------------- |
 | **Today**                               | The current day.                        |
-| **Last 7 days** / **Last 14 days**      | The last 1–2 weeks.                      |
+| **Last 7 days** / **Last 14 days**      | The last 1–2 weeks.                     |
 | **Last 30 days** _(default)_            | The last month.                         |
 | **Last 3 Months** / **Last 12 Months**  | The last quarter / year.                |
 | **Month to Date** / **Quarter to Date** | From the start of this month / quarter. |
@@ -89,9 +84,8 @@ Click **Print** in the toolbar to print the current dashboard — or use your br
 
 <Callout>
   {" "}
-  **Tip:** An **Updating…** badge appears briefly while the dashboard refreshes
-  its numbers — the data is close to real time, so recent activity shows up
-  quickly.
+  **Tip:** An **Updating…** badge appears briefly while the dashboard refreshes its
+  numbers — the data is close to real time, so recent activity shows up quickly.
 </Callout>
 
 ---
@@ -111,24 +105,24 @@ The free dashboard covers the essentials. **[Masteriyo Pro](https://masteriyo.co
 
 ![The Pro Analytics Dashboard with sales metrics and charts](https://img.masteriyo.com/w:auto/h:auto/q:auto/id:2a385b45cdb421877f9e0f04f975cd3b/directUpload/Revenue.png)
 
-| Capability                                                     | Free | Pro |
-| -------------------------------------------------------------- | ---- | --- |
-| Content / People / Engagement metrics                          | ✓    | ✓   |
-| Enrollment chart                                               | ✓    | ✓   |
-| Date range & course filter                                     | ✓    | ✓   |
-| Print / save as PDF                                            | ✓    | ✓   |
+| Capability                                                      | Free | Pro |
+| --------------------------------------------------------------- | ---- | --- |
+| Content / People / Engagement metrics                           | ✓    | ✓   |
+| Enrollment chart                                                | ✓    | ✓   |
+| Date range & course filter                                      | ✓    | ✓   |
+| Print / save as PDF                                             | ✓    | ✓   |
 | **Sales metrics** (earnings, refunds, orders, net revenue, AOV) | —    | ✓   |
-| **All charts** (Sales, Subscriptions, Learning Activity, etc.) | —    | ✓   |
-| **Period-over-period comparison** (▲/▼ % change)               | —    | ✓   |
-| **Customizable dashboard** (add / remove / reorder, saved)     | —    | ✓   |
-| **Scope & bundle filters** (All / Courses / Bundles)           | —    | ✓   |
-| **Per-course, student & instructor reports + commission**      | —    | ✓   |
+| **All charts** (Sales, Subscriptions, Learning Activity, etc.)  | —    | ✓   |
+| **Period-over-period comparison** (▲/▼ % change)                | —    | ✓   |
+| **Customizable dashboard** (add / remove / reorder, saved)      | —    | ✓   |
+| **Scope & bundle filters** (All / Courses / Bundles)            | —    | ✓   |
+| **Per-course, student & instructor reports + commission**       | —    | ✓   |
 
 <Callout>
   {" "}
-  **Note:** Some Pro metrics depend on their add-ons — for example **Total
-  Certificates** (Certificate), **Total Assignments** (Assignment), **Total
-  Groups** (Group Courses), and **Bundles Sold** (Course Bundle).
+  **Note:** Some Pro metrics depend on their add-ons — for example **Total Certificates**
+  (Certificate), **Total Assignments** (Assignment), **Total Groups** (Group Courses),
+  and **Bundles Sold** (Course Bundle).
 </Callout>
 
 ---

--- a/200-course-creation/305-course-analytics.mdx
+++ b/200-course-creation/305-course-analytics.mdx
@@ -39,7 +39,7 @@ Below the chart, switch between tabs:
 
 - **Enrolled Students** — the students taking this course (see below).
 - **Instructors** — the course's instructors (Name, Username, Email).
-- **Commissions** — the instructor/admin earnings split. *(Only with the Revenue Sharing add-on.)*
+- **Commissions** — the instructor/admin earnings split. _(Only with the Revenue Sharing add-on.)_
 
 ---
 

--- a/200-course-creation/305-course-analytics.mdx
+++ b/200-course-creation/305-course-analytics.mdx
@@ -1,40 +1,86 @@
 ---
 title: Advanced Analytics for Courses [Pro]
 show_child_cards: true
-excerpt: This section helps the instructor to analyze various aspects of the courses they create.
+excerpt: Open a detailed report for any single course — metric cards, enrollment and sales charts, enrolled students with progress, instructors, and commission — and mark progress or reset it.
 ---
 
 ## Advanced Analytics for Courses
 
-Masteriyo provides individual course reports. To access a report for each course, including student activity and progress, go to your **Dashboard > Masteriyo > Courses**. Click the three dots next to a course, then select the **"Reports"** button. 
+Masteriyo Pro gives every course its own detailed report — content counts, enrollment and sales trends, the list of enrolled students with their progress, instructors, and (with Revenue Sharing) a commission breakdown.
 
-![masteriyo-courses-analytics](https://github.com/Masteriyo/masteriyo-docs/assets/75772539/eccf5458-fc6f-416a-a0f6-92162dbf9674)
+There are two ways to open a course's report:
 
-This will show advanced analytics for that course, including sales, enrollment, and student progress.   
+- From **Masteriyo > Courses**, click the three dots on a course and choose **Reports**.
+- From the [Analytics Dashboard](https://docs.masteriyo.com/getting-started/analytics-dashboard), open the **Courses** list and click **Details** on a course.
 
-![advanced-analytics-dashboard](https://github.com/user-attachments/assets/69238aad-119a-4086-a757-7781c6ea963a)
+---
 
-### Student's Progress
+## The course report
 
-To check the progress of the enrolled students, scroll to the Enrolled Students section. Here, you will find the list of the students enrolled in the respective course. You can click the **Progress** button for each student to check and modify their progress.
+At the top of the report you can fine-tune the view:
 
-![enrolled-students-progress](https://github.com/Masteriyo/masteriyo-docs/assets/75772539/8ee29ed8-509d-407a-8365-ada797412374)  
+- **Date range** — pick the period to analyze (defaults to the last 30 days).
+- **Interval** — group the chart by **Day**, **Week**, or **Month**.
+- **Print** — print the report or save it as a PDF.
 
+![A single course's analytics report](https://img.masteriyo.com/w:auto/h:auto/q:auto/id:b498e8d5d4f04d6fd1cfe8087e099676/directUpload/Single_Course_Analytics.png)
 
-#### Mark as Complete [Pro]
-Administrators can override user progress statuses through two methods:  
+### Metric cards
 
-![mark-as-complete-for-course](https://github.com/user-attachments/assets/39d70ff5-bc11-477e-9f55-b4e4313cb14e)
+Four metric cards summarize the course. By default they show **Total Lessons**, **Total Quizzes**, **Total Questions**, and **Total Reviews**. Click a card's title to swap it for another — **Total Q&A**, **Total Students**, or **Total Instructors**.
 
-  - **Mark All As Complete:** Mark an entire course as completed for specific users.    
-  - **Mark as Complete:** Manually mark individual course components (lessons, quizzes, assignments, etc.) as completed.  
-This feature is ideal for correcting progress tracking errors or accommodating exceptional circumstances.  
+### Charts
 
-#### Reset Progress [Pro]
-This functionality enables administrators to:  
-  - Reset user progress for entire courses through the Reset Progress button. It removes all completion records, quiz attempts, and tracked metrics associated with the selected course.  
+The report includes an **Enrollment** chart and a **Sales** chart. Use the chart menu to switch between them, and the series checkboxes to show or hide lines for **Students Enrolled**, **Course Completions**, **Lesson Completions**, and **Quiz Completions**.
 
-![reset-progress-for-course](https://github.com/user-attachments/assets/9705c0ab-2485-4ac6-ad06-467c720812ba)
+### Tables
 
-**Note:** This action is irreversible. Users will need to restart progress from the beginning.
+Below the chart, switch between tabs:
 
+- **Enrolled Students** — the students taking this course (see below).
+- **Instructors** — the course's instructors (Name, Username, Email).
+- **Commissions** — the instructor/admin earnings split. *(Only with the Revenue Sharing add-on.)*
+
+---
+
+## Enrolled students
+
+The **Enrolled Students** tab lists everyone taking the course, with their **Username**, **Email**, and a **Progress** bar.
+
+- **Search** students by username or email.
+- **Add Student** — enroll a student into the course manually.
+- **Unenroll** — remove a student (this also erases their progress and related data).
+- **Progress** — open that student's detailed progress report.
+
+---
+
+## A student's progress report
+
+Click **Progress** next to a student to open their report for the course. Here you can review and adjust how far they've come.
+
+### Activity summary
+
+If **user activity tracking** is enabled, the report shows the student's **Last Access**, **Access Count**, **Time Spent**, and **Idle Time** — both for the course overall and for each item.
+
+### Sections and items
+
+Each section expands to show its lessons, quizzes, and assignments. Completed items show a green check (with the completion date); items not yet done show a **Mark as Complete** button.
+
+### Mark as Complete [Pro]
+
+Administrators can override a student's progress:
+
+- **Mark All As Complete** — mark the entire course complete for the student. You can choose to notify the student, instructor, and admin by email.
+- **Mark as Complete** — mark an individual item (lesson, quiz, assignment, etc.) complete.
+
+This is ideal for correcting tracking errors or accommodating exceptional circumstances.
+
+![Mark a course or item as complete](https://img.masteriyo.com/w:auto/h:auto/q:auto/id:10171e1a71e5caa3ed6240ce7b5f043e/directUpload/Student_Progress.png)
+
+### Reset Progress [Pro]
+
+Use **Reset Progress** to clear all of the student's progress for the course — completion records, quiz attempts, and tracked metrics.
+
+![Reset a student's course progress](https://img.masteriyo.com/w:auto/h:auto/q:auto/id:f266c34a7f1f8df9f944e6719de6a625/directUpload/Reset_Progress.png)
+
+**Note:** This action is irreversible. The student will need to start the course again from the beginning.


### PR DESCRIPTION
## Summary

Documents Masteriyo's **Analytics Dashboard** and refreshes the **per-course analytics** doc to match the redesigned Pro UI.

### New: Analytics Dashboard (`100-getting-started/420-analytics-dashboard.mdx`)
Covers the main dashboard at **Masteriyo > Dashboard**:
- Metric cards (Content / People / Engagement groups) and how to switch them
- The Enrollment chart (line/bar)
- Date-range presets + custom range, and the course filter
- Print / save as PDF
- Who sees what (admins/managers vs instructors)
- **Free vs Pro** comparison (sales metrics, all charts, comparisons, customization, scope/bundle filters, per-course/student/instructor reports)
- A short FAQ
- Includes an overview video and screenshots

### Updated: Advanced Analytics for Courses (`200-course-creation/305-course-analytics.mdx`)
Rewritten for the redesigned per-course report:
- Two access paths (Courses → ⋮ → Reports, and Analytics → Courses → Details)
- Report controls (date range, Day/Week/Month interval, Print)
- Metric cards, Enrollment/Sales charts, and the Enrolled Students / Instructors / Commissions tabs
- Enrolled students (search, Add Student, Unenroll, Progress)
- Student progress report: Activity summary, per-item completion, **Mark as Complete** / **Mark All As Complete**, **Reset Progress**
- Refreshed screenshots

The two docs cross-link to each other.

## Notes
- Content verified against the free and Pro plugin code; Free vs Pro split is accurate.
- Verified by inspection (no build step in this repo).
