### PR TITLE
docs: clarify Webhook and Zoom plan availability

### DIFF
--- a/300-premium-addons/310-zoom-integration.mdx
+++ b/300-premium-addons/310-zoom-integration.mdx
@@ -1,10 +1,12 @@
 ---
-title: Zoom Integration
+title: Zoom Integration [Pro]
 show_child_cards: true
-excerpt: Zoom Integration add-on allows the instructors to create Zoom class sessions for the courses they create.
+excerpt: Use the Pro-only Zoom Integration add-on to create Zoom class sessions for your courses.
 ---
 
-Our Zoom integration simplifies the virtual classroom experience by allowing instructors to schedule and launch meetings directly from the platform. Students can access the virtual classroom, participate in live sessions, and interact with their peers and instructors in real-time, all within the Masteriyo plugin.
+Zoom Integration is available in Masteriyo Pro and Elite. It is not included in Free or Basic.
+
+The integration simplifies the virtual classroom experience by allowing instructors to schedule and launch meetings directly from the platform. Students can access the virtual classroom, participate in live sessions, and interact with their peers and instructors in real-time, all within the Masteriyo plugin.
 
 ## Before you begin:
 

--- a/630-masteriyo-tools/150-webhooks.mdx
+++ b/630-masteriyo-tools/150-webhooks.mdx
@@ -1,20 +1,25 @@
 ---
 title: Webhooks
 show_child_cards: true
-excerpt: Set up Masteriyo webhooks to send real-time course, enrollment, and quiz data to external apps, or receive incoming actions from Zapier and other tools.
+excerpt: Trigger webhooks are available in every Masteriyo plan, including Free. Incoming action webhooks require Masteriyo Pro or Elite.
 ---
 
 **Webhooks** are a powerful feature in Masteriyo that enables real-time communication between your WordPress LMS and external applications. This documentation covers both types of webhook functionality available in Masteriyo:
 
-**Trigger Webhooks (Outgoing)**: Send data from Masteriyo to external applications when specific events occur in your LMS.        
+| Webhook capability | Available in |
+| --- | --- |
+| **Trigger Webhooks (Outgoing)** | Free, Basic, Pro, and Elite |
+| **Action Webhooks (Incoming)** | Pro and Elite |
 
-**Action Webhooks (Incoming)**: Allow external applications to trigger actions within Masteriyo.        
+**Trigger Webhooks (Outgoing)** send data from Masteriyo to external applications when specific events occur in your LMS.
+
+**Action Webhooks (Incoming)** allow external applications to trigger actions within Masteriyo.
 
 ## What are Webhooks?
 Webhooks allow different applications to communicate automatically with each other in real-time. When an event occurs in one application, it can notify another through webhooks, triggering specific actions or transferring data without manual intervention.
 
-## Trigger Webhooks (Outgoing Data)
-Trigger webhooks send data from your Masteriyo LMS to external applications whenever specific events occur on your site.
+## Trigger Webhooks (Outgoing Data) [Free]
+Trigger webhooks are included in Masteriyo Free and every paid plan. They send data from your Masteriyo LMS to external applications whenever specific events occur on your site.
 
 ### Setting Up Trigger Webhooks
 1. Navigate to **Masteriyo > Webhooks** in your WordPress admin dashboard.   


### PR DESCRIPTION
## Summary

- state explicitly that outgoing Trigger Webhooks are available in Free and every paid plan
- keep incoming Action Webhooks labeled as Pro and Elite
- label Zoom Integration as Pro and state that it is not included in Free or Basic

## Verification

- checked existing Zoom references in course creation and account settings; both already label Zoom as Pro
- ran `git diff --check`
- no new links or assets added

## Related website follow-up

- Codeinwp/learning-management-system-pro#629

The pricing page separately needs to remove Zoom from Basic and stop presenting generic Webhooks and API Access as Pro-only.